### PR TITLE
feat: add global error boundary to prevent app crashes

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -14,7 +15,8 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Emotional Mirror - Understand Yourself",
-  description: "A gentle web app to help you recognize emotional patterns in relationships",
+  description:
+    "A gentle web app to help you recognize emotional patterns in relationships",
 };
 
 export const viewport: Viewport = {
@@ -33,9 +35,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-hidden bg-gradient-to-br from-slate-50 via-orange-50 to-rose-50`}
       >
-        <div className="flex flex-col h-screen w-screen overflow-hidden">
-          {children}
-        </div>
+        <ErrorBoundary>
+          <div className="flex flex-col h-screen w-screen overflow-hidden">
+            {children}
+          </div>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React from 'react';
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // Log error (can be replaced with Sentry later)
+    console.error('Application crashed:', error, errorInfo);
+  }
+
+  reloadPage = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            minHeight: '100vh',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '2rem',
+            textAlign: 'center',
+          }}
+        >
+          <h1>Something went wrong</h1>
+          <p>
+            An unexpected error occurred. Please reload the page to continue.
+          </p>
+          <button
+            onClick={this.reloadPage}
+            style={{
+              marginTop: '1rem',
+              padding: '0.6rem 1.2rem',
+              cursor: 'pointer',
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
This PR adds a global React Error Boundary to prevent the application from crashing with a white screen when a runtime error occurs.

## Problem
A runtime error in any component caused the entire app to become unusable, forcing users to refresh the page.

## Solution
- Added a reusable ErrorBoundary component
- Wrapped the root layout with the ErrorBoundary
- Displayed a user-friendly fallback UI with a reload option

## Result
Runtime rendering errors are now gracefully handled, improving application stability and user experience.

Fixes #3
